### PR TITLE
Add systemd service for FastAPI API

### DIFF
--- a/api/skyblock-api.service
+++ b/api/skyblock-api.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Gunicorn instance to serve SkyBlock LXD Manager API
+After=network.target
+
+[Service]
+User=jules
+Group=jules
+WorkingDirectory=/app/api
+EnvironmentFile=/app/api/.env
+ExecStart=/app/api/venv/bin/gunicorn app.main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Creates a proper systemd service file for Gunicorn running the FastAPI SkyBlock island management API. The service is configured to restart on failure, run as the correct user, and load environment variables from a `.env` file in the API directory.

---
*PR created automatically by Jules for task [9620382640876550778](https://jules.google.com/task/9620382640876550778) started by @Igor5877*