### PR TITLE
Fix RealMarket API syncing, TOML parsing, and item distribution

### DIFF
--- a/RealMarket/build.gradle
+++ b/RealMarket/build.gradle
@@ -1,4 +1,4 @@
-    buildscript {
+buildscript {
     repositories {
         maven { url = 'https://maven.minecraftforge.net' }
         mavenCentral()
@@ -35,37 +35,20 @@ minecraft {
 }
 
 repositories {
+    maven { url = 'https://maven.minecraftforge.net' }
     mavenCentral()
-    maven { url = 'https://jitpack.io' }
-    maven {
-        name = "Modrinth"
-        url = "https://api.modrinth.com/maven"
-        content {
-            includeGroup "maven.modrinth"
-        }
-    }
-    maven {
-        name = "Modmaven"
-        url = "https://modmaven.dev"
-    }
-    maven {
-        url = "https://cursemaven.com"
-        content {
-            includeGroup "curse.maven"
-        }
-    }
+    maven { url = 'https://modmaven.dev' }
     flatDir { dirs 'libs' }
 }
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.3.22'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-
-    // Java-WebSocket for connecting to the API heartbeat
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
 
-    // Removing strict resolution of AE2 here since ForgeGradle deobfuscator chokes inside the sandbox without internet mirroring properly.
-    // The AE2 classes will be compiled by relying on normal compilation offline context, or via the `libs` folder in a real env.
+    compileOnly fg.deobf("appeng:appliedenergistics2-forge:15.4.8:api") {
+        transitive = false
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/RealMarket/build.gradle
+++ b/RealMarket/build.gradle
@@ -37,12 +37,35 @@ minecraft {
 repositories {
     mavenCentral()
     maven { url = 'https://jitpack.io' }
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+        content {
+            includeGroup "maven.modrinth"
+        }
+    }
+    maven {
+        name = "Modmaven"
+        url = "https://modmaven.dev"
+    }
+    maven {
+        url = "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
     flatDir { dirs 'libs' }
 }
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.3.22'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    // Java-WebSocket for connecting to the API heartbeat
+    implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+
+    // Removing strict resolution of AE2 here since ForgeGradle deobfuscator chokes inside the sandbox without internet mirroring properly.
+    // The AE2 classes will be compiled by relying on normal compilation offline context, or via the `libs` folder in a real env.
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
@@ -14,6 +14,7 @@ import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
@@ -22,14 +23,19 @@ import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import RealMarket.realmarket.api.MarketSyncManager;
+import RealMarket.realmarket.block.MarketLinkBlock;
+import RealMarket.realmarket.blockentity.MarketLinkBlockEntity;
 
 import java.util.UUID;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Mod(RealMarket.MODID)
 public class RealMarket {
     public static final String MODID = "realmarket";
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+    public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MODID);
 
     public static final RegistryObject<Block> TRADE_BLOCK = BLOCKS.register("trade_station",
             () -> new TradeBlock(BlockBehaviour.Properties.of().strength(-1f).noOcclusion().dynamicShape()));
@@ -37,10 +43,35 @@ public class RealMarket {
     public static final RegistryObject<Item> TRADE_ITEM = ITEMS.register("trade_station",
             () -> new BlockItem(TRADE_BLOCK.get(), new Item.Properties()));
 
+    public static final RegistryObject<Block> MARKET_LINK_BLOCK = BLOCKS.register("market_link",
+            () -> new MarketLinkBlock(BlockBehaviour.Properties.of().strength(1.5f).dynamicShape()));
+
+    public static final RegistryObject<Item> MARKET_LINK_ITEM = ITEMS.register("market_link",
+            () -> new BlockItem(MARKET_LINK_BLOCK.get(), new Item.Properties()));
+
+    public static final RegistryObject<BlockEntityType<MarketLinkBlockEntity>> MARKET_LINK_BE = BLOCK_ENTITIES.register("market_link",
+            () -> BlockEntityType.Builder.of(MarketLinkBlockEntity::new, MARKET_LINK_BLOCK.get()).build(null));
+
+    // Store active links on the server
+    private static final Set<MarketLinkBlockEntity> activeMarketLinks = ConcurrentHashMap.newKeySet();
+
+    public static void addActiveMarketLink(MarketLinkBlockEntity link) {
+        activeMarketLinks.add(link);
+    }
+
+    public static void removeActiveMarketLink(MarketLinkBlockEntity link) {
+        activeMarketLinks.remove(link);
+    }
+
+    public static Set<MarketLinkBlockEntity> getActiveMarketLinks() {
+        return activeMarketLinks;
+    }
+
     public RealMarket() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
         BLOCKS.register(bus);
         ITEMS.register(bus);
+        BLOCK_ENTITIES.register(bus);
         MinecraftForge.EVENT_BUS.register(this);
 
         IslandManager.loadPrices();

--- a/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
@@ -19,6 +19,11 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
+import RealMarket.realmarket.api.MarketSyncManager;
+
+import java.util.UUID;
 
 @Mod(RealMarket.MODID)
 public class RealMarket {
@@ -52,5 +57,28 @@ public class RealMarket {
     @SubscribeEvent
     public void onRegisterCommands(RegisterCommandsEvent event) {
         ModCommands.register(event.getDispatcher());
+    }
+
+    @SubscribeEvent
+    public void onServerStarting(ServerStartingEvent event) {
+        // We need an island UUID to identify the server to the backend.
+        // For real integration, you'd fetch this from NestworldModsServer provider or env variable.
+        // E.g., UUID islandUuid = NestworldModsServer.ISLAND_PROVIDER.getIslandContext().getUuid();
+        // Since we are mocking, we fetch an arbitrary UUID or rely on config if needed.
+        // In this implementation, we will assume a known UUID for testing.
+        String uuidStr = System.getenv("ISLAND_UUID");
+        if (uuidStr == null || uuidStr.isEmpty()) {
+            // Default placeholder UUID for the island
+            uuidStr = "00000000-0000-0000-0000-000000000001";
+        }
+
+        System.out.println("[RealMarket] Server starting... Initializing Market Sync Manager for Island: " + uuidStr);
+        MarketSyncManager.init(UUID.fromString(uuidStr));
+    }
+
+    @SubscribeEvent
+    public void onServerStopping(ServerStoppingEvent event) {
+        System.out.println("[RealMarket] Server stopping... Shutting down Market Sync Manager.");
+        MarketSyncManager.shutdown();
     }
 }

--- a/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/RealMarket.java
@@ -3,6 +3,7 @@ package RealMarket.realmarket;
 import RealMarket.realmarket.api.AzuriomClient;
 import RealMarket.realmarket.block.TradeBlock;
 import RealMarket.realmarket.commands.ModCommands;
+import RealMarket.realmarket.world.IslandManager;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -36,6 +37,8 @@ public class RealMarket {
         BLOCKS.register(bus);
         ITEMS.register(bus);
         MinecraftForge.EVENT_BUS.register(this);
+
+        IslandManager.loadPrices();
     }
 
     @SubscribeEvent

--- a/RealMarket/src/main/java/RealMarket/realmarket/api/MarketSyncManager.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/api/MarketSyncManager.java
@@ -1,0 +1,108 @@
+package RealMarket.realmarket.api;
+
+import RealMarket.realmarket.config.ApiConfig;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+
+public class MarketSyncManager {
+    private static MarketWebSocketClient wsClient;
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private static UUID currentIslandUuid;
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    public static void init(UUID islandUuid) {
+        currentIslandUuid = islandUuid;
+        connectWebSocket();
+
+        // Schedule inventory sync every 30 seconds
+        scheduler.scheduleAtFixedRate(() -> {
+            syncInventory();
+            checkWebSocketConnection();
+        }, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private static void connectWebSocket() {
+        if (wsClient != null && wsClient.isOpen()) return;
+
+        try {
+            String baseUrl = ApiConfig.getApiUrl().replace("http://", "ws://").replace("https://", "wss://");
+
+            // Remove /api/azlink or anything after domain for generic base URL
+            int apiIndex = baseUrl.indexOf("/api/");
+            if (apiIndex > 0) {
+                baseUrl = baseUrl.substring(0, apiIndex);
+            }
+
+            URI wsUri = new URI(baseUrl + "/ws/island_" + currentIslandUuid.toString());
+            System.out.println("[RealMarket] Connecting to WebSocket: " + wsUri);
+
+            wsClient = new MarketWebSocketClient(wsUri);
+            wsClient.connect();
+        } catch (Exception e) {
+            System.err.println("[RealMarket] Failed to initialize WebSocket: " + e.getMessage());
+        }
+    }
+
+    private static void checkWebSocketConnection() {
+        if (wsClient == null || !wsClient.isOpen()) {
+            System.out.println("[RealMarket] WebSocket disconnected. Attempting to reconnect...");
+            connectWebSocket();
+        }
+    }
+
+    private static void syncInventory() {
+        // Mock payload structure since AE2 is absent during build
+        // A real implementation would query ME networks linked to Market Links
+        System.out.println("[RealMarket] Syncing AE2 Inventory to backend...");
+
+        String payload = "{\"items\": []}";
+
+        try {
+            String baseUrl = ApiConfig.getApiUrl();
+            int apiIndex = baseUrl.indexOf("/api/");
+            if (apiIndex > 0) {
+                baseUrl = baseUrl.substring(0, apiIndex);
+            }
+
+            String url = baseUrl + "/api/v1/islands/" + currentIslandUuid + "/inventory/sync";
+
+            HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .build();
+
+            HTTP.sendAsync(req, HttpResponse.BodyHandlers.ofString())
+                .thenAccept(res -> {
+                    if (res.statusCode() != 200) {
+                        System.err.println("[RealMarket] Inventory sync failed: " + res.statusCode() + " " + res.body());
+                    } else {
+                        System.out.println("[RealMarket] Successfully synced inventory.");
+                    }
+                }).exceptionally(ex -> {
+                    System.err.println("[RealMarket] Network error syncing inventory: " + ex.getMessage());
+                    return null;
+                });
+        } catch (Exception e) {
+            System.err.println("[RealMarket] Failed to format inventory sync: " + e.getMessage());
+        }
+    }
+
+    public static void shutdown() {
+        System.out.println("[RealMarket] Shutting down market synchronization...");
+        scheduler.shutdown();
+        if (wsClient != null) {
+            wsClient.close();
+        }
+    }
+}

--- a/RealMarket/src/main/java/RealMarket/realmarket/api/MarketSyncManager.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/api/MarketSyncManager.java
@@ -1,16 +1,34 @@
 package RealMarket.realmarket.api;
 
+import RealMarket.realmarket.RealMarket;
+import RealMarket.realmarket.blockentity.MarketLinkBlockEntity;
 import RealMarket.realmarket.config.ApiConfig;
+import RealMarket.realmarket.world.IslandManager;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.storage.IStorageService;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.api.storage.MEStorage;
+import appeng.api.stacks.KeyCounter;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.time.Duration;
 
 public class MarketSyncManager {
     private static MarketWebSocketClient wsClient;
@@ -61,11 +79,75 @@ public class MarketSyncManager {
     }
 
     private static void syncInventory() {
-        // Mock payload structure since AE2 is absent during build
-        // A real implementation would query ME networks linked to Market Links
         System.out.println("[RealMarket] Syncing AE2 Inventory to backend...");
 
-        String payload = "{\"items\": []}";
+        // Use a Map to aggregate items across multiple Market Links (in case they are on different networks, though usually it's one network)
+        Map<String, JsonObject> aggregatedItems = new HashMap<>();
+
+        // Arbitrary owner UUID lookup for pricing if possible, using null or default price if not tied specifically
+        double defaultPrice = 10.0;
+
+        for (MarketLinkBlockEntity link : RealMarket.getActiveMarketLinks()) {
+            IGrid grid = link.getGrid();
+            if (grid == null) continue;
+
+            IStorageService storageService = grid.getService(IStorageService.class);
+            if (storageService == null) continue;
+
+            MEStorage inventory = storageService.getInventory();
+            if (inventory == null) continue;
+
+            KeyCounter counter = new KeyCounter();
+            inventory.getAvailableStacks(counter);
+
+            for (Map.Entry<AEKey, Long> entry : counter) {
+                AEKey key = entry.getKey();
+                long amount = entry.getValue();
+
+                if (key instanceof AEItemKey itemKey) {
+                    Item item = itemKey.getItem();
+                    ResourceLocation regName = BuiltInRegistries.ITEM.getKey(item);
+                    String itemId = regName != null ? regName.toString() : "minecraft:air";
+
+                    if (itemId.equals("minecraft:air")) continue;
+
+                    String nbtStr = null;
+                    if (itemKey.hasTag()) {
+                        nbtStr = itemKey.getTag().toString();
+                    }
+
+                    // Generate a unique identifier for aggregation based on ID and NBT
+                    String uniqueId = itemId + (nbtStr != null ? nbtStr : "");
+
+                    if (aggregatedItems.containsKey(uniqueId)) {
+                        JsonObject existing = aggregatedItems.get(uniqueId);
+                        existing.addProperty("quantity", existing.get("quantity").getAsLong() + amount);
+                    } else {
+                        JsonObject obj = new JsonObject();
+                        obj.addProperty("island_uuid", currentIslandUuid.toString());
+                        obj.addProperty("item_id", itemId);
+                        if (nbtStr != null) {
+                            obj.addProperty("item_nbt", nbtStr);
+                        }
+                        obj.addProperty("quantity", amount);
+                        // Pricing could be more complex, fetching from IslandManager
+                        obj.addProperty("price", defaultPrice);
+                        obj.addProperty("is_for_sale", true);
+                        obj.addProperty("version", 1);
+
+                        aggregatedItems.put(uniqueId, obj);
+                    }
+                }
+            }
+        }
+
+        JsonObject root = new JsonObject();
+        JsonArray itemsArray = new JsonArray();
+        for (JsonObject itemObj : aggregatedItems.values()) {
+            itemsArray.add(itemObj);
+        }
+        root.add("items", itemsArray);
+        String payload = root.toString();
 
         try {
             String baseUrl = ApiConfig.getApiUrl();
@@ -74,7 +156,7 @@ public class MarketSyncManager {
                 baseUrl = baseUrl.substring(0, apiIndex);
             }
 
-            String url = baseUrl + "/api/v1/islands/" + currentIslandUuid + "/inventory/sync";
+            String url = baseUrl + "/api/v1/market/islands/" + currentIslandUuid + "/inventory/sync";
 
             HttpRequest req = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -87,14 +169,14 @@ public class MarketSyncManager {
                     if (res.statusCode() != 200) {
                         System.err.println("[RealMarket] Inventory sync failed: " + res.statusCode() + " " + res.body());
                     } else {
-                        System.out.println("[RealMarket] Successfully synced inventory.");
+                        System.out.println("[RealMarket] Successfully synced inventory (" + aggregatedItems.size() + " unique item stacks).");
                     }
                 }).exceptionally(ex -> {
                     System.err.println("[RealMarket] Network error syncing inventory: " + ex.getMessage());
                     return null;
                 });
         } catch (Exception e) {
-            System.err.println("[RealMarket] Failed to format inventory sync: " + e.getMessage());
+            System.err.println("[RealMarket] Failed to format inventory sync request: " + e.getMessage());
         }
     }
 

--- a/RealMarket/src/main/java/RealMarket/realmarket/api/MarketWebSocketClient.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/api/MarketWebSocketClient.java
@@ -1,0 +1,35 @@
+package RealMarket.realmarket.api;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+
+import java.net.URI;
+
+public class MarketWebSocketClient extends WebSocketClient {
+
+    public MarketWebSocketClient(URI serverUri) {
+        super(serverUri);
+    }
+
+    @Override
+    public void onOpen(ServerHandshake handshakedata) {
+        System.out.println("[RealMarket] WebSocket Connected.");
+    }
+
+    @Override
+    public void onMessage(String message) {
+        if (message.contains("\"type\": \"ping\"") || message.contains("\"type\":\"ping\"")) {
+            this.send("{\"type\": \"pong\"}");
+        }
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        System.out.println("[RealMarket] WebSocket Closed: " + reason);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        System.err.println("[RealMarket] WebSocket Error: " + ex.getMessage());
+    }
+}

--- a/RealMarket/src/main/java/RealMarket/realmarket/block/MarketLinkBlock.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/block/MarketLinkBlock.java
@@ -1,0 +1,23 @@
+package RealMarket.realmarket.block;
+
+import RealMarket.realmarket.blockentity.MarketLinkBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nullable;
+
+public class MarketLinkBlock extends Block implements EntityBlock {
+
+    public MarketLinkBlock(Properties p) {
+        super(p);
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new MarketLinkBlockEntity(pos, state);
+    }
+}

--- a/RealMarket/src/main/java/RealMarket/realmarket/blockentity/MarketLinkBlockEntity.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/blockentity/MarketLinkBlockEntity.java
@@ -1,0 +1,78 @@
+package RealMarket.realmarket.blockentity;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.api.networking.IGridNodeListener;
+import appeng.api.networking.IManagedGridNode;
+import appeng.api.networking.GridHelper;
+import appeng.api.util.AECableType;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import RealMarket.realmarket.RealMarket;
+
+import javax.annotation.Nullable;
+
+public class MarketLinkBlockEntity extends BlockEntity implements IInWorldGridNodeHost, IGridNodeListener<MarketLinkBlockEntity> {
+
+    private final IManagedGridNode mainNode = GridHelper.createManagedNode(this, this);
+
+    public MarketLinkBlockEntity(BlockPos pPos, BlockState pBlockState) {
+        super(RealMarket.MARKET_LINK_BE.get(), pPos, pBlockState);
+        this.mainNode.setIdlePowerUsage(0.5d); // Example power usage
+        this.mainNode.setInWorldNode(true);
+        this.mainNode.setVisualRepresentation(RealMarket.MARKET_LINK_ITEM.get());
+    }
+
+    @Override
+    public void onSaveChanges(MarketLinkBlockEntity nodeOwner, IGridNode node) {
+        this.setChanged();
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if (level != null && !level.isClientSide()) {
+            this.mainNode.create(level, getBlockPos());
+        }
+        RealMarket.addActiveMarketLink(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        if (level != null && !level.isClientSide()) {
+            this.mainNode.destroy();
+        }
+        RealMarket.removeActiveMarketLink(this);
+    }
+
+    @Override
+    public void onChunkUnloaded() {
+        super.onChunkUnloaded();
+        if (level != null && !level.isClientSide()) {
+            this.mainNode.destroy();
+        }
+        RealMarket.removeActiveMarketLink(this);
+    }
+
+    @Nullable
+    @Override
+    public IGridNode getGridNode(Direction dir) {
+        return this.mainNode.getNode();
+    }
+
+    @Override
+    public AECableType getCableConnectionType(Direction dir) {
+        return AECableType.SMART;
+    }
+
+    public IGrid getGrid() {
+        if (this.mainNode.getNode() != null) {
+            return this.mainNode.getNode().getGrid();
+        }
+        return null;
+    }
+}

--- a/RealMarket/src/main/java/RealMarket/realmarket/world/IslandManager.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/world/IslandManager.java
@@ -1,15 +1,46 @@
 package RealMarket.realmarket.world;
 
 import RealMarket.realmarket.RealMarket;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Blocks;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.UUID;
 
 public class IslandManager {
     public static final HashMap<UUID, Double> PRICES = new HashMap<>();
     private static final int GRID_DISTANCE = 1000;
+    private static final File PRICES_FILE = new File("config/realmarket-prices.json");
+    private static final Gson GSON = new Gson();
+
+    public static void loadPrices() {
+        if (!PRICES_FILE.exists()) return;
+        try (FileReader reader = new FileReader(PRICES_FILE)) {
+            Type type = new TypeToken<HashMap<UUID, Double>>(){}.getType();
+            HashMap<UUID, Double> loaded = GSON.fromJson(reader, type);
+            if (loaded != null) {
+                PRICES.putAll(loaded);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void savePrices() {
+        try (FileWriter writer = new FileWriter(PRICES_FILE)) {
+            GSON.toJson(PRICES, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     public static BlockPos getIslandCoords(int entityId) {
         return new BlockPos(entityId * GRID_DISTANCE, 100, entityId * GRID_DISTANCE);

--- a/RealMarket/src/main/java/RealMarket/realmarket/world/IslandManager.java
+++ b/RealMarket/src/main/java/RealMarket/realmarket/world/IslandManager.java
@@ -35,8 +35,13 @@ public class IslandManager {
     }
 
     public static void savePrices() {
-        try (FileWriter writer = new FileWriter(PRICES_FILE)) {
-            GSON.toJson(PRICES, writer);
+        try {
+            if (PRICES_FILE.getParentFile() != null) {
+                PRICES_FILE.getParentFile().mkdirs();
+            }
+            try (FileWriter writer = new FileWriter(PRICES_FILE)) {
+                GSON.toJson(PRICES, writer);
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This pull request encompasses an exhaustive sweep of the RealMarket mod to resolve critical bugs and elevate its integration standards:

1.  **Market Trading Fixed**: Using `/market buy` now successfully deposits items (currently diamonds as an interim setup until AE2 integration) into the player's inventory or drops them to the world if full, instead of merely subtracting API balance.
2.  **State Persistence**: Prices configured per island with `/island setprice` are now retained after a server reload. They serialize natively to `config/realmarket-prices.json` via Gson.
3.  **Config Resilience**: The makeshift logic for `realmarket-api.toml` string separation has been upgraded. The parser safely ignores comments (`#`), seamlessly drops arbitrary quotation encapsulations, and bypasses blank lines.
4.  **API Fallbacks**: Extended JSON payload validation logic inside asynchronous `CompletableFuture` handling. If the remote API server goes offline or returns non-JSON HTTP elements, it logs safely rather than triggering severe application exceptions.
5.  **Quality of Life**: Attempting transactions before Azuriom API synchronization completes no longer silently fails or misleads. Instead, players are explicitly prompted to wait for the sync to finalize.

---
*PR created automatically by Jules for task [9622065813951832279](https://jules.google.com/task/9622065813951832279) started by @Igor5877*