### PR TITLE
Fix gradlew path in GitHub Actions

### DIFF
--- a/.github/workflows/_build-java.yml
+++ b/.github/workflows/_build-java.yml
@@ -53,7 +53,7 @@ jobs:
         run: chmod +x "${{ inputs.module_path }}/gradlew"
 
       - name: Build
-        run: ./gradlew -p "${{ inputs.module_path }}" ${{ inputs.gradle_tasks }}
+        run: "${{ inputs.module_path }}/gradlew" -p "${{ inputs.module_path }}" ${{ inputs.gradle_tasks }}
 
       - name: Locate JAR
         id: jar


### PR DESCRIPTION
Fixed the missing `./gradlew` file error in the GitHub Actions workflow by using the `gradlew` script specific to the module being built.

---
*PR created automatically by Jules for task [17679000701376523887](https://jules.google.com/task/17679000701376523887) started by @Igor5877*